### PR TITLE
Reduce memory usage of IPInfo provider and use region IDs over region names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo apt install ipmeta
 
 ### From Release Tarball
 
-1. Install [libwandio](https://research.wand.net.nz/software/libwandio.php).
+1. Install [libwandio](https://github.com/LibtraceTeam/wandio).
 2. Download a [release](https://github.com/CAIDA/libipmeta/releases).
 
 Then:

--- a/configure.ac
+++ b/configure.ac
@@ -34,13 +34,13 @@
 AC_PREREQ([2.68])
 
 # Package version should use semantic versioning.
-AC_INIT([libipmeta], [3.2.0], [software@caida.org])
+AC_INIT([libipmeta], [3.2.1], [software@caida.org])
 AM_INIT_AUTOMAKE([foreign])
 
 # Version numbers for the libtool-created library (libipmeta) are unrelated
 # to the overall package version.  For details on Library Versioning, see
 # https://www.sourceware.org/autobook/autobook/autobook_61.html
-LIBIPMETA_LIBTOOL_VERSION=5:2:1
+LIBIPMETA_LIBTOOL_VERSION=5:3:1
 
 LT_INIT
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libipmeta2 (3.2.1-1) unstable; urgency=medium
+
+  * Remove repeated call to AM_INIT_AUTOMAKE in configure.ac.
+  * Drop rows of maxmind data that are missing latitude/longitude.
+
+ -- Brendon Jones <software@caida.org>  Mon, 02 Oct 2023 11:21:51 +1300
+
 libipmeta2 (3.2.0) unstable; urgency=medium
 
   * Various code tidy-ups, no functionality has changed.

--- a/lib/ipmeta.c
+++ b/lib/ipmeta.c
@@ -80,16 +80,29 @@ ipmeta_t *ipmeta_init(enum ipmeta_ds_id dstype)
     return NULL;
   }
   ipmeta_log(__func__, "using datastore %s", ipmeta->datastore->name);
-
+  for (i = 0; i < IPMETA_GEO_DETAIL_LAST; i++) {
+    ipmeta->fqid_caches[i] = kh_init(fqid_hash);
+  }
   return ipmeta;
 }
 
 void ipmeta_free(ipmeta_t *ipmeta)
 {
   int i;
+  khiter_t k;
 
   /* no mercy for double frees */
   assert(ipmeta != NULL);
+
+  for (i = 0; i < IPMETA_GEO_DETAIL_LAST; i++) {
+    for (k = 0; k < kh_end(ipmeta->fqid_caches[i]); ++k) {
+      if (kh_exist(ipmeta->fqid_caches[i], k)) {
+        free((void *)kh_key(ipmeta->fqid_caches[i], k));
+        free((void *)kh_value(ipmeta->fqid_caches[i], k));
+      }
+    }
+    kh_destroy(fqid_hash, ipmeta->fqid_caches[i]);
+  }
 
   /* loop across all providers and free each one */
   for (i = 0; i < IPMETA_PROVIDER_MAX; i++) {
@@ -383,6 +396,118 @@ void ipmeta_dump_record_header()
   ipmeta_write_record_header(NULL);
 }
 
+const char *ipmeta_derive_geo_fqid_from_record(ipmeta_t *ipmeta,
+        ipmeta_record_t *record, ipmeta_detail_t level) {
+
+    char *fqid = NULL;
+    char *ptr;
+    khiter_t k;
+    char *key = NULL;
+    int ret;
+
+    if (record->source == IPMETA_PROVIDER_PFX2AS) {
+        return NULL;
+    }
+
+    switch(level) {
+        case IPMETA_GEO_DETAIL_CONTINENT:
+            key = record->continent_code;
+            break;
+        case IPMETA_GEO_DETAIL_COUNTRY:
+            key = record->country_code;
+            break;
+        case IPMETA_GEO_DETAIL_REGION:
+            key = record->region;
+            break;
+        case IPMETA_GEO_DETAIL_CITY:
+            key = record->city;
+            break;
+    }
+
+    if (key == NULL) {
+        return NULL;
+    }
+
+    if (ipmeta) {
+        /* See if we've already derived and cached the fqid for this
+         * particular record's location
+         */
+        k = kh_get(fqid_hash, ipmeta->fqid_caches[level], key);
+        if (k != kh_end(ipmeta->fqid_caches[level])) {
+            fqid = (char *) kh_value(ipmeta->fqid_caches[level], k);
+        }
+    }
+
+    if (fqid) {
+        return (const char *)fqid;
+    }
+
+    fqid = (char *)calloc(256, sizeof(char));
+    if (fqid == NULL) {
+        return NULL;
+    }
+    ptr = fqid;
+
+    if (level >= IPMETA_GEO_DETAIL_CONTINENT) {
+        memcpy(ptr, record->continent_code, 2);
+        ptr += 2;
+    }
+
+    if (level >= IPMETA_GEO_DETAIL_COUNTRY) {
+        *ptr = '.';
+        ptr ++;
+
+        memcpy(ptr, record->country_code, 2);
+        ptr += 2;
+    }
+
+    if (level >= IPMETA_GEO_DETAIL_REGION) {
+        if (record->region == NULL) {
+            free(fqid);
+            return NULL;
+        }
+        *ptr = '.';
+        ptr ++;
+
+        if (strlen(record->region) > (255 - (ptr - fqid))) {
+            /* not enough room */
+            free(fqid);
+            return NULL;
+        }
+
+        memcpy(ptr, record->region, strlen(record->region));
+        ptr += strlen(record->region);
+    }
+
+    if (level >= IPMETA_GEO_DETAIL_CITY) {
+        if (record->city == NULL) {
+            free(fqid);
+            return NULL;
+        }
+        *ptr = '.';
+        ptr ++;
+
+        if (strlen(record->city) > (255 - (ptr - fqid))) {
+            /* not enough room */
+            free(fqid);
+            return NULL;
+        }
+        memcpy(ptr, record->city, strlen(record->city));
+        ptr += strlen(record->city);
+    }
+
+    if (ipmeta) {
+        /* cache this fqid */
+        k = kh_put(fqid_hash, ipmeta->fqid_caches[level], key, &ret);
+        if (ret >= 0) {
+            kh_key(ipmeta->fqid_caches[level], k) = strdup(key);
+            kh_value(ipmeta->fqid_caches[level], k) = fqid;
+        }
+    }
+
+    return (const char *)fqid;
+}
+
 void ipmeta_write_record(iow_t *file, ipmeta_record_t *record, char *ip_str,
                          uint64_t num_ips)
 {
@@ -424,6 +549,7 @@ void ipmeta_write_record(iow_t *file, ipmeta_record_t *record, char *ip_str,
     } else {
       ipmeta_printf(file, "|");
     }
+
     ipmeta_printf(file,
              "%s" SEPARATOR "%d" "\n",
              record->timezone == NULL ? "" : record->timezone,

--- a/lib/ipmeta_provider.h
+++ b/lib/ipmeta_provider.h
@@ -191,6 +191,11 @@ struct ipmeta_provider {
   /** An opaque pointer to provider-specific state if needed by the provider */
   void *state;
 
+  /** A cache of all FQIDs for each geographic entity recognised by this
+   *  provider.
+   */
+  kh_fqid_hash_t *fqid_caches[IPMETA_GEO_DETAIL_LAST];
+
   /** }@ */
 };
 

--- a/lib/libipmeta.h
+++ b/lib/libipmeta.h
@@ -100,6 +100,14 @@ typedef enum ipmeta_provider_id {
 
 } ipmeta_provider_id_t;
 
+typedef enum ipmeta_detail {
+    IPMETA_GEO_DETAIL_CONTINENT = 2,
+    IPMETA_GEO_DETAIL_COUNTRY = 3,
+    IPMETA_GEO_DETAIL_REGION = 4,
+    IPMETA_GEO_DETAIL_CITY = 5,
+    IPMETA_GEO_DETAIL_LAST,
+} ipmeta_detail_t;
+
 /** A unique identifier for each metadata ds that libipmeta supports.
  *
  * @note When adding a datastructure to this list, there must also be a
@@ -529,6 +537,29 @@ void ipmeta_write_record(iow_t *file, ipmeta_record_t *record, char *ip_str,
  * order as the contents are written out when using ipmeta_write_record.
  */
 void ipmeta_write_record_header(iow_t *file);
+
+/** Derives a suitable FQID for the location described by the given
+ *  ipmeta record.
+ *
+ *  @param ipmeta   An ipmeta instance. If not NULL, the derived FQID will
+ *                  be cached to speed up future calls to this method for
+ *                  the same location.
+ *  @param record   The record to get an FQID for.
+ *  @param level    The level of geographic detail that the FQID must provide
+ *
+ *  @return a string containing the desired FQID, or NULL if there was
+ *          insufficient detail in the record to produce the requested FQID.
+ *
+ *  @note VERY IMPORTANT: if the caller provides NULL as the ipmeta parameter,
+ *        then the caller MUST free the returned string when they are finished
+ *        with it. If the ipmeta parameter is NOT NULL, then the caller MUST
+ *        NOT free the FQID string, as the ipmeta instance will handle that
+ *        when it is destroyed.
+ *  @note this method will return NULL if called on a record with no
+ *        geographic information (i.e. only ASN data).
+ */
+const char *ipmeta_derive_geo_fqid_from_record(ipmeta_t *ipmeta,
+        ipmeta_record_t *record, ipmeta_detail_t level);
 
 /** Get an array of all the metadata records registered with the given
  *  provider

--- a/lib/libipmeta.h
+++ b/lib/libipmeta.h
@@ -541,8 +541,9 @@ void ipmeta_write_record_header(iow_t *file);
 /** Derives a suitable FQID for the location described by the given
  *  ipmeta record.
  *
- *  @param ipmeta   An ipmeta instance. If not NULL, the derived FQID will
- *                  be cached to speed up future calls to this method for
+ *  @param provider An ipmeta provider instance.
+ *                  If not NULL, the derived FQID will be cached to speed up
+ *                  future calls to this method for
  *                  the same location.
  *  @param record   The record to get an FQID for.
  *  @param level    The level of geographic detail that the FQID must provide
@@ -550,15 +551,15 @@ void ipmeta_write_record_header(iow_t *file);
  *  @return a string containing the desired FQID, or NULL if there was
  *          insufficient detail in the record to produce the requested FQID.
  *
- *  @note VERY IMPORTANT: if the caller provides NULL as the ipmeta parameter,
+ *  @note VERY IMPORTANT: if the caller provides NULL as the provider parameter,
  *        then the caller MUST free the returned string when they are finished
- *        with it. If the ipmeta parameter is NOT NULL, then the caller MUST
- *        NOT free the FQID string, as the ipmeta instance will handle that
+ *        with it. If the provider parameter is NOT NULL, then the caller MUST
+ *        NOT free the FQID string, as the provider instance will handle that
  *        when it is destroyed.
  *  @note this method will return NULL if called on a record with no
  *        geographic information (i.e. only ASN data).
  */
-const char *ipmeta_derive_geo_fqid_from_record(ipmeta_t *ipmeta,
+const char *ipmeta_derive_geo_fqid_from_record(ipmeta_provider_t *provider,
         ipmeta_record_t *record, ipmeta_detail_t level);
 
 /** Get an array of all the metadata records registered with the given

--- a/lib/libipmeta_int.h
+++ b/lib/libipmeta_int.h
@@ -51,6 +51,8 @@
 
 KHASH_MAP_INIT_INT(ipmeta_rechash, struct ipmeta_record *)
 
+KHASH_MAP_INIT_STR(fqid_hash, const char *)
+
 /**
  * @name Internal Datastructures
  *
@@ -70,6 +72,8 @@ struct ipmeta {
   struct ipmeta_ds *datastore;
 
   uint32_t all_provmask;
+
+  kh_fqid_hash_t *fqid_caches[IPMETA_GEO_DETAIL_LAST];
 };
 
 /** Structure which holds a set of records, returned by a query */

--- a/lib/libipmeta_int.h
+++ b/lib/libipmeta_int.h
@@ -72,8 +72,6 @@ struct ipmeta {
   struct ipmeta_ds *datastore;
 
   uint32_t all_provmask;
-
-  kh_fqid_hash_t *fqid_caches[IPMETA_GEO_DETAIL_LAST];
 };
 
 /** Structure which holds a set of records, returned by a query */

--- a/lib/providers/ipmeta_provider_ipinfo.c
+++ b/lib/providers/ipmeta_provider_ipinfo.c
@@ -233,6 +233,9 @@ static void insert_ipinfo_record(ipmeta_provider_t *provider,
     u16_to_c2(cont, state->record->continent_code);
 
     ipmeta_provider_insert_record(provider, state->record);
+    /* pre-cache record FQIDs for faster future lookup */
+    ipmeta_derive_geo_fqid_from_record(provider, state->record,
+            IPMETA_GEO_DETAIL_REGION);
 
     if (ipvx_range_to_prefix(&state->block_lower_first,
             &state->block_upper_last, &pfx_list) != 0) {

--- a/lib/providers/ipmeta_provider_ipinfo.c
+++ b/lib/providers/ipmeta_provider_ipinfo.c
@@ -241,8 +241,7 @@ static void insert_ipinfo_record(ipmeta_provider_t *provider,
     if (state->record->region) {
         char *endptr;
         unsigned long conv = strtoul(state->record->region, &endptr, 10);
-        if ((errno == ERANGE && (conv == ULONG_MAX || conv == 0)) ||
-                (errno != 0 && conv == 0)) {
+        if ((errno == EINVAL || errno == ERANGE) && conv == ULONG_MAX) {
             fprintf(stderr,
                 "ERROR: strtoul failure (input was '%s')\n",
                 state->record->region);

--- a/tools/ipinfo-preprocess.sh
+++ b/tools/ipinfo-preprocess.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+OPTSTRING=":u:r:i:o:"
+
+usage() {
+    >&2 echo "Required arguments: "
+    >&2 echo "    -u <file>    File containing the unknown region codes for each country."
+    >&2 echo "    -r <file>    File containing the region names and IDs for each lat-long pair."
+    >&2 echo "    -i <file>    The IPInfo data file to process."
+    >&2 echo "    -o <file>    The file to write the processed output to. "
+    >&2 echo "                 Note that this file will be gzip-compressed."
+
+    exit 1
+}
+
+UNKNOWN=""
+REGIONMAP=""
+INPUT=""
+OUTPUT=""
+
+while getopts ${OPTSTRING} opt; do
+    case $opt in
+        u)
+            UNKNOWN=$OPTARG
+            ;;
+        r)
+            REGIONMAP=$OPTARG
+            ;;
+        i)
+            INPUT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        \?)
+            usage
+            ;;
+        :)
+            usage
+            ;;
+    esac
+done
+
+if [[ ${UNKNOWN} == "" ]]; then
+    echo "-u option must be set"
+    usage
+fi
+if [[ ${REGIONMAP} == "" ]]; then
+    echo "-r option must be set"
+    usage
+fi
+if [[ ${INPUT} == "" ]]; then
+    echo "-i option must be set"
+    usage
+fi
+if [[ ${OUTPUT} == "" ]]; then
+    echo "-o option must be set"
+    usage
+fi
+
+echo "Preprocessing ${INPUT}"
+
+python3 process-ipinfo.py -u ${UNKNOWN} -l ${REGIONMAP} -i ${INPUT} -o /tmp/ipinfo-processed.gz
+
+echo "Processing complete, sorting output...."
+
+zcat /tmp/ipinfo-processed.gz | grep -v ":" | sort -k1,1 -k2,2 -k3,3 -k4,4 -n -t. | gzip -1 -c > ${OUTPUT}
+
+rm /tmp/ipinfo-processed.gz

--- a/tools/process-ipinfo.py
+++ b/tools/process-ipinfo.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+
+import sys, string, argparse, csv, gzip
+import ipaddress
+
+latlongs = {}
+
+def parse_unknowns_file(unkfile):
+    unknowns = {}
+
+    with open(unkfile, "r") as f:
+        for line in f:
+            s = line.strip().split(",")
+            if len(s) != 2:
+                continue
+            unknowns[s[0]] = s[1]
+
+    return unknowns
+
+def parse_latlong_file(llfile):
+    latlongs = {}
+    with open(llfile, newline='') as f:
+        reader = csv.reader(f, delimiter=',')
+        for row in reader:
+            assert(len(row) == 6)
+            if row[0] == "latitude":
+                continue
+            if (row[0], row[1]) not in latlongs:
+                latlongs[(row[0], row[1])] = row[3]
+    return latlongs
+
+def lookup_region(cc, lat, longg, unknowns, latlongs):
+    if (lat, longg) in latlongs:
+        return latlongs[(lat, longg)]
+
+    if cc not in unknowns:
+        return "0"
+    return unknowns[cc]
+
+def process_ipinfo_for_ioda(ipfile, outpath, unknowns, latlongs):
+    try:
+        with gzip.open(outpath, "wt") as out:
+            out.write("start_ip,end_ip,region,country\n")
+            with gzip.open(ipfile, "rt", newline='') as ff:
+                reader = csv.reader(ff, delimiter=',')
+                for row in reader:
+                    assert(len(row) == 10)
+                    if row[0] == "start_ip":
+                        continue
+                    cc = row[5]
+                    start = row[0]
+                    end = row[1]
+                    region = lookup_region(cc, row[6], row[7], unknowns,
+                            latlongs)
+                    out.write("%s,%s,%s,%s\n" % (start, end, region, cc))
+    except IOError as e:
+        print(f'IO Error: {e}')
+        return
+    except Exception as e:
+        print(f'Unexpected Error: {e}')
+        return
+
+parser = argparse.ArgumentParser();
+parser.add_argument("-u", "--unknown", type=str, help="File containing the unknown region codes for each country code")
+parser.add_argument("-l", "--latlongs", type=str, help="File containing the IODA region ID that matches each lat-long datapoint in an IPInfo snapshot")
+parser.add_argument("-i", "--ipinfo", type=str, help="The IPInfo snapshot file to process")
+parser.add_argument("-o", "--output", type=str, help="The file to write the processed output into")
+
+args = parser.parse_args()
+
+if args.unknown is None:
+    print("Error: must provide location of unknown region codes file")
+    parser.print_help()
+    sys.exit(1)
+
+
+if args.latlongs is None:
+    print("Error: must provide location of lat-long to region mappings file")
+    parser.print_help()
+    sys.exit(1)
+
+
+if args.ipinfo is None:
+    print("Error: must provide an IPInfo snapshot file")
+    parser.print_help()
+    sys.exit(1)
+
+if args.output is None:
+    print("Error: must provide a path for an output file")
+    parser.print_help()
+    sys.exit(1)
+
+unknowns = parse_unknowns_file(args.unknown)
+latlongs = parse_latlong_file(args.latlongs)
+
+process_ipinfo_for_ioda(args.ipinfo, args.output, unknowns, latlongs)


### PR DESCRIPTION
These changes are designed to optimize IPInfo for IODA specifically -- they may not be suitable for other use cases...

IPInfo input must now undergo a pre-processing step. The locations file provided using the `-l` argument should now point to the output from the pre-processing, not the data file from IPInfo.

The `ipinfo-preprocess.sh` script in `tools/` can be used to perform the pre-processing on IPInfo data -- note that some additional input files are required.

Other changes:
 * Adjacent entries that have the same country code and region will now be combined into a single record.
 * Add API method (`ipmeta_derive_geo_fqid_from_record()`) that can derive the FQID for a location described in a particular IPmeta record.
 * Store IPInfo region code in the IPmeta record as a uint16_t.